### PR TITLE
Chore: Adds manifest for yarn 2 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "icons",
+  "version": "1.0.0",
+  "description": "Icons for Grafana",
+  "repository": "https://github.com/grafana/icons.git",
+  "author": "Grafana Labs",
+  "license": "Apache-2.0"
+}


### PR DESCRIPTION
Adds a manifest file (package.json) so that the repo can be pointed to and used as a dependency with yarn 2.