### PR TITLE
Add missing trailing slash on icons public path

### DIFF
--- a/cmd/genbundle/main.go
+++ b/cmd/genbundle/main.go
@@ -27,7 +27,7 @@ func main() {
 import { cacheStore } from 'react-inlinesvg';
 
 export let cacheInitialized = false;
-export let iconRoot = 'public/img/icons';
+export let iconRoot = 'public/img/icons/';
 
 function cacheItem(content: string, path: string) {
 	cacheStore[iconRoot + path] = { content, status: 'loaded', queue: [] };


### PR DESCRIPTION
This path was already fixed in the grafana repository here: https://github.com/grafana/grafana/pull/53736

The missing trailing slash prevents the network request for icons fallback to work. 

Note: I am trying to remove the usage of this script and all this repository here https://github.com/grafana/grafana/pull/53766